### PR TITLE
Fix cpu cg mat comp

### DIFF
--- a/src/cg.hpp
+++ b/src/cg.hpp
@@ -85,7 +85,7 @@ auto inner_product(const Vector& a, const Vector& b)
 /// @param b Vector RHS
 /// @param max_iter Maximum number of iterations
 /// @param rtol Tolerance (default 0.0 will enforce max_iter iterations)
-template <typename Operator, typename Vector, typename S, bool UseMult = false>
+template <typename Operator, typename Vector, typename S>
 int cg_solve(Operator& A, Vector& x, const Vector& b, int max_iter,
              S rtol = 0.0)
 {
@@ -104,13 +104,7 @@ int cg_solve(Operator& A, Vector& x, const Vector& b, int max_iter,
   Vector p(x.index_map(), x.bs());
 
   // Compute initial residual r0 = b - Ax0
-  if constexpr (UseMult)
-  {
-    std::fill(y.array().begin(), y.array().end(), 0);
-    A.mult(x, y);
-  }
-  else
-    A.apply(x, y);
+  A.apply(x, y);
   detail::axpy(r, -1, y, b);
   detail::axpy(p, 0.0, r, r);
 
@@ -129,13 +123,7 @@ int cg_solve(Operator& A, Vector& x, const Vector& b, int max_iter,
 
     // MatVec
     // y = A.p;
-    if constexpr (UseMult)
-    {
-      std::fill(y.array().begin(), y.array().end(), 0);
-      A.mult(p, y);
-    }
-    else
-      A.apply(p, y);
+    A.apply(p, y);
 
     // Calculate alpha = r.r/p.y
     const T alpha = rnorm / detail::inner_product(p, y);

--- a/src/cg.hpp
+++ b/src/cg.hpp
@@ -85,7 +85,7 @@ auto inner_product(const Vector& a, const Vector& b)
 /// @param b Vector RHS
 /// @param max_iter Maximum number of iterations
 /// @param rtol Tolerance (default 0.0 will enforce max_iter iterations)
-template <typename Operator, typename Vector, typename S>
+template <typename Operator, typename Vector, typename S, bool UseMult = false>
 int cg_solve(Operator& A, Vector& x, const Vector& b, int max_iter,
              S rtol = 0.0)
 {
@@ -104,7 +104,13 @@ int cg_solve(Operator& A, Vector& x, const Vector& b, int max_iter,
   Vector p(x.index_map(), x.bs());
 
   // Compute initial residual r0 = b - Ax0
-  A.apply(x, y);
+  if constexpr (UseMult)
+  {
+    std::fill(y.array().begin(), y.array().end(), 0);
+    A.mult(x, y);
+  }
+  else
+    A.apply(x, y);
   detail::axpy(r, -1, y, b);
   detail::axpy(p, 0.0, r, r);
 
@@ -123,7 +129,13 @@ int cg_solve(Operator& A, Vector& x, const Vector& b, int max_iter,
 
     // MatVec
     // y = A.p;
-    A.apply(p, y);
+    if constexpr (UseMult)
+    {
+      std::fill(y.array().begin(), y.array().end(), 0);
+      A.mult(p, y);
+    }
+    else
+      A.apply(p, y);
 
     // Calculate alpha = r.r/p.y
     const T alpha = rnorm / detail::inner_product(p, y);

--- a/src/laplacian_solver.cpp
+++ b/src/laplacian_solver.cpp
@@ -324,17 +324,25 @@ BenchmarkResults benchdolfinx::laplace_action_cpu(
 
     dolfinx::la::SparsityPattern sp = dolfinx::fem::create_sparsity_pattern(a);
     sp.finalize();
+
     dolfinx::la::MatrixCSR<T> mat_op(sp);
     dolfinx::fem::assemble_matrix(mat_op.mat_add_values(), a, {bc});
     mat_op.scatter_rev();
     dolfinx::fem::set_diagonal<T>(mat_op.mat_set_values(), *V, {bc}, 1.0);
 
     dolfinx::common::Timer mtimer("% CSR Matvec");
-    for (int i = 0; i < nreps; ++i)
+    if (use_cg)
     {
-      std::fill(z.array().begin(), z.array().end(), 0);
-
-      mat_op.mult(u, z);
+      cg_solve<dolfinx::la::MatrixCSR<T>, dolfinx::la::Vector<T>, T, true>(
+          mat_op, z, u, nreps, T(0.0));
+    }
+    else
+    {
+      for (int i = 0; i < nreps; ++i)
+      {
+        std::fill(z.array().begin(), z.array().end(), 0);
+        mat_op.mult(u, z);
+      }
     }
     mtimer.stop();
 

--- a/src/laplacian_solver.cpp
+++ b/src/laplacian_solver.cpp
@@ -243,6 +243,24 @@ benchdolfinx::laplace_action_gpu<float>(const dolfinx::fem::Form<float>&,
                                         int, int, float, int, bool, bool, bool);
 /// @endcond
 #endif
+
+template <typename T>
+class CPUMatrixOperator
+{
+public:
+  using value_type = T;
+
+  CPUMatrixOperator(std::shared_ptr<dolfinx::la::MatrixCSR<T>> A) : _A(A) {}
+
+  void apply(dolfinx::la::Vector<T>& x, dolfinx::la::Vector<T>& y)
+  {
+    std::fill(y.array().begin(), y.array().end(), 0);
+    _A->mult(x, y);
+  }
+
+  std::shared_ptr<dolfinx::la::MatrixCSR<T>> _A;
+};
+
 //----------------------------------------------------------------------------
 template <typename T>
 BenchmarkResults benchdolfinx::laplace_action_cpu(
@@ -325,24 +343,21 @@ BenchmarkResults benchdolfinx::laplace_action_cpu(
     dolfinx::la::SparsityPattern sp = dolfinx::fem::create_sparsity_pattern(a);
     sp.finalize();
 
-    dolfinx::la::MatrixCSR<T> mat_op(sp);
-    dolfinx::fem::assemble_matrix(mat_op.mat_add_values(), a, {bc});
-    mat_op.scatter_rev();
-    dolfinx::fem::set_diagonal<T>(mat_op.mat_set_values(), *V, {bc}, 1.0);
+    auto mat_op = std::make_shared<dolfinx::la::MatrixCSR<T>>(sp);
+    dolfinx::fem::assemble_matrix(mat_op->mat_add_values(), a, {bc});
+    mat_op->scatter_rev();
+    dolfinx::fem::set_diagonal<T>(mat_op->mat_set_values(), *V, {bc}, 1.0);
+    CPUMatrixOperator<T> cpu_mat_op(mat_op);
 
     dolfinx::common::Timer mtimer("% CSR Matvec");
     if (use_cg)
     {
-      cg_solve<dolfinx::la::MatrixCSR<T>, dolfinx::la::Vector<T>, T, true>(
-          mat_op, z, u, nreps, T(0.0));
+      cg_solve(cpu_mat_op, z, u, nreps, T(0.0));
     }
     else
     {
       for (int i = 0; i < nreps; ++i)
-      {
-        std::fill(z.array().begin(), z.array().end(), 0);
-        mat_op.mult(u, z);
-      }
+        cpu_mat_op.apply(u, z);
     }
     mtimer.stop();
 


### PR DESCRIPTION
Allow matrix comparison when using CPU and CG loops.
Requires wrapping MatrixCSR, as it provides `mult` and not `apply`.